### PR TITLE
fix instructions to be more consistent with the use of jupyter

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,9 @@ A step-by-step guide to download all the codes from here and test yourself in yo
   cd Code-Sleep-python
   cd Code-Sleep-Python  # all the codes are present Here
 
-  ipython notebook
+  pip install jupyterlab
+
+  jupyter notebook
 
 ```
 This will open a new jupyter notebook in your localhost where you can run all the codes and test it for yourself.


### PR DESCRIPTION
The readme references jupyter several times but the instructions call `ipython notebook`. This will be confusing to people. `ipython` is also the old term for it and `jupyter` should be used now. There is also no mention of how to install it so I added that as a step too.